### PR TITLE
Redirect newrelic log output to a different file.

### DIFF
--- a/src/servers/rest_server/newrelic.ini
+++ b/src/servers/rest_server/newrelic.ini
@@ -52,7 +52,7 @@ monitor_mode = true
 # write out a log file, it is also possible to say "stderr" and
 # output to standard error output. This would normally result in
 # output appearing in your web server log.
-#log_file = /tmp/newrelic-python-agent.log
+log_file = /var/log/hint/newrelic-python-agent.log
 
 # Sets the level of detail of messages sent to the log file, if
 # a log file location has been provided. Possible values, in


### PR DESCRIPTION
Make sure when deploying this change to preserve the license key that's on the server.